### PR TITLE
Implement Hashing to Reduce Database Bloat in Sync Command

### DIFF
--- a/.github/workflows/scripts/generate_index.php
+++ b/.github/workflows/scripts/generate_index.php
@@ -15,19 +15,16 @@ function update_readme($categories) {
         $category = ucwords($category);
         fwrite($readme, "\n## $category\n");
         // Sort templates alphabetically within each category
-        usort($templates, function($a, $b) { return strcmp($a['name'], $b['name']); });
+        usort($templates, function($a, $b) { return strcmp($a['template_details']['card-title'], $b['template_details']['card-title']); });
         
         foreach ($templates as $template) {
-            foreach ($template as $value) {
-                $string = "- **[{$value['name']}](/{$value['relative_path']})**: {$value['description']}";
-                if ($value['version']) {
-                    $string .= " (Version {$value['version']})\n";
-                } else {
-                    $string .= "\n";
-                }
-                fwrite($readme, $string);
+            $string = "- **[{$template['template_details']['card-title']}]**: {$template['template_details']['modal-description']}";
+            if ($template['template_details']['version']) {
+                $string .= " (Version {$template['template_details']['version']})\n";
+            } else {
+                $string .= "\n";
             }
-
+            fwrite($readme, $string);
         }
     }
     fclose($readme);
@@ -75,13 +72,18 @@ function main()
         }
     }
 
+    ksort($categories);
     file_put_contents("index.json", json_encode($categories, JSON_PRETTY_PRINT));
+
+    update_readme($categories);
 }
 
 function initializeTemplateStructure()
 {
     return [
+        "helper_process_hash" => "",
         "helper_process" => "",
+        "template_process_hash" => "",
         "template_process" => "",
         "config_collection" => "",
         "template_details" => [
@@ -187,9 +189,13 @@ function mapContentToTemplateStructure($contentInfo, &$categories, $currentCateg
 
     switch ($fileName) {
         case "process_helper_export":
+            $data = json_decode(file_get_contents($contentInfo->getPathname()), true);
+            $categories[$currentCategory][$templateName]['helper_process_hash'] = compute_hash(json_encode($data['export'][$data['root']]['attributes']));
             $categories[$currentCategory][$templateName]['helper_process'] = $contentInfo->getPathname();
             break;
         case "process_template_export":
+            $data = json_decode(file_get_contents($contentInfo->getPathname()), true);
+            $categories[$currentCategory][$templateName]['template_process_hash'] = compute_hash(json_encode($data['export'][$data['root']]['attributes']));
             $categories[$currentCategory][$templateName]['template_process'] = $contentInfo->getPathname();
             break;
         case "wizard-template-details":

--- a/.github/workflows/scripts/generate_index.php
+++ b/.github/workflows/scripts/generate_index.php
@@ -15,12 +15,20 @@ function update_readme($categories) {
         $category = ucwords($category);
         fwrite($readme, "\n## $category\n");
         // Sort templates alphabetically within each category
-        usort($templates, function($a, $b) { return strcmp($a['template_details']['card-title'], $b['template_details']['card-title']); });
+        usort($templates, function($a, $b) {
+            $aTitle = isset($a['template_details']['card-title']) ? $a['template_details']['card-title'] : '';
+            $bTitle = isset($b['template_details']['card-title']) ? $b['template_details']['card-title'] : '';
+            return strcmp($aTitle, $bTitle);
+        });
         
         foreach ($templates as $template) {
-            $string = "- **[{$template['template_details']['card-title']}]**: {$template['template_details']['modal-description']}";
-            if ($template['template_details']['version']) {
-                $string .= " (Version {$template['template_details']['version']})\n";
+            $string = "- **[";
+            $title = isset($template['template_details']['card-title']) ? $template['template_details']['card-title'] : '';
+            $desc = isset($template['template_details']['modal-description']) ? $template['template_details']['modal-description'] : '';
+            $version = isset($template['template_details']['version']) ? $template['template_details']['version'] : '';
+            $string .= "{$title}]**: {$desc}";
+            if ($version) {
+                $string .= " (Version {$version})\n";
             } else {
                 $string .= "\n";
             }
@@ -190,12 +198,16 @@ function mapContentToTemplateStructure($contentInfo, &$categories, $currentCateg
     switch ($fileName) {
         case "process_helper_export":
             $data = json_decode(file_get_contents($contentInfo->getPathname()), true);
-            $categories[$currentCategory][$templateName]['template_details']['helper_process_hash'] = compute_hash(json_encode($data['export'][$data['root']]['attributes']));
+            if (isset($data['export'][$data['root']]['attributes'])) {
+                $categories[$currentCategory][$templateName]['template_details']['helper_process_hash'] = compute_hash(json_encode($data['export'][$data['root']]['attributes']));
+            }
             $categories[$currentCategory][$templateName]['helper_process'] = $contentInfo->getPathname();
             break;
         case "process_template_export":
             $data = json_decode(file_get_contents($contentInfo->getPathname()), true);
-            $categories[$currentCategory][$templateName]['template_details']['template_process_hash'] = compute_hash(json_encode($data['export'][$data['root']]['attributes']));
+            if (isset($data['export'][$data['root']]['attributes'])) {
+                $categories[$currentCategory][$templateName]['template_details']['template_process_hash'] = compute_hash(json_encode($data['export'][$data['root']]['attributes']));
+            }
             $categories[$currentCategory][$templateName]['template_process'] = $contentInfo->getPathname();
             break;
         case "wizard-template-details":

--- a/.github/workflows/scripts/generate_index.php
+++ b/.github/workflows/scripts/generate_index.php
@@ -81,9 +81,7 @@ function main()
 function initializeTemplateStructure()
 {
     return [
-        "helper_process_hash" => "",
         "helper_process" => "",
-        "template_process_hash" => "",
         "template_process" => "",
         "config_collection" => "",
         "template_details" => [
@@ -93,6 +91,8 @@ function initializeTemplateStructure()
             "modal-description" => "",
             'version' => "",
             'unique-template-id' => "",
+            "helper_process_hash" => "",
+            "template_process_hash" => "",
         ],
         "assets" => [
             "icon" => "",
@@ -190,12 +190,12 @@ function mapContentToTemplateStructure($contentInfo, &$categories, $currentCateg
     switch ($fileName) {
         case "process_helper_export":
             $data = json_decode(file_get_contents($contentInfo->getPathname()), true);
-            $categories[$currentCategory][$templateName]['helper_process_hash'] = compute_hash(json_encode($data['export'][$data['root']]['attributes']));
+            $categories[$currentCategory][$templateName]['template_details']['helper_process_hash'] = compute_hash(json_encode($data['export'][$data['root']]['attributes']));
             $categories[$currentCategory][$templateName]['helper_process'] = $contentInfo->getPathname();
             break;
         case "process_template_export":
             $data = json_decode(file_get_contents($contentInfo->getPathname()), true);
-            $categories[$currentCategory][$templateName]['template_process_hash'] = compute_hash(json_encode($data['export'][$data['root']]['attributes']));
+            $categories[$currentCategory][$templateName]['template_details']['template_process_hash'] = compute_hash(json_encode($data['export'][$data['root']]['attributes']));
             $categories[$currentCategory][$templateName]['template_process'] = $contentInfo->getPathname();
             break;
         case "wizard-template-details":

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # Wizard Templates
 Enhance the usability and functionality of ProcessMaker. These templates offer seamless integration with various tools by allowing users to declare their accounts. Users can easily select a template of their choice, eliminating the need to go through the modeler.
+## Accounting And Finance
+- **[Expense Report]**: Improve Expense Oversight with Efficient Data Management (Version 2.1.1 )
+- **[Guided Invoice Approval]**: Drive action and measure your impact with a continuous, real-time tracking of invoices (Version 2.1.14)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Wizard Templates
 Enhance the usability and functionality of ProcessMaker. These templates offer seamless integration with various tools by allowing users to declare their accounts. Users can easily select a template of their choice, eliminating the need to go through the modeler.
 ## Accounting And Finance
-- **[Expense Report]**: Improve Expense Oversight with Efficient Data Management (Version 2.1.1 )
+- **[Expense Report]**: Improve Expense Oversight with Efficient Data Management (Version 2.1.2)
 - **[Guided Invoice Approval]**: Drive action and measure your impact with a continuous, real-time tracking of invoices (Version 2.1.14)

--- a/index.json
+++ b/index.json
@@ -1,7 +1,9 @@
 {
     "accounting-and-finance": {
         "expense_report": {
+            "helper_process_hash": "84fe0234ac04ba1747a5e4d94e88429b61c472d4",
             "helper_process": ".\/accounting-and-finance\/expense_report\/process_helper_export.json",
+            "template_process_hash": "9127188deb597df15107ab380e1cd222299e61dc",
             "template_process": ".\/accounting-and-finance\/expense_report\/process_template_export.json",
             "config_collection": "",
             "template_details": {
@@ -33,7 +35,9 @@
             "connected_accounts": []
         },
         "invoice_approval": {
+            "helper_process_hash": "a9ddb4f9656e3634df0cd718b1d1f2ab8143b028",
             "helper_process": ".\/accounting-and-finance\/invoice_approval\/process_helper_export.json",
+            "template_process_hash": "d66789e831d0564a2dbee235949a9f1b67716a46",
             "template_process": ".\/accounting-and-finance\/invoice_approval\/process_template_export.json",
             "config_collection": "",
             "template_details": {

--- a/index.json
+++ b/index.json
@@ -12,7 +12,7 @@
                 "version": "2.1.2",
                 "unique-template-id": "expense_report",
                 "helper_process_hash": "84fe0234ac04ba1747a5e4d94e88429b61c472d4",
-                "template_process_hash": "9127188deb597df15107ab380e1cd222299e61dc"
+                "template_process_hash": "d2c656028e99a8dc533971cf640e7fbad4b6722f"
             },
             "assets": {
                 "icon": ".\/accounting-and-finance\/expense_report\/assets\/icon.png",
@@ -25,10 +25,10 @@
                 "launchpad": {
                     "process-card-background": "",
                     "slides": [
+                        ".\/accounting-and-finance\/expense_report\/assets\/launchpad\/slides\/launchpad-slide1.jpg",
                         ".\/accounting-and-finance\/expense_report\/assets\/launchpad\/slides\/launchpad-slide3.jpg",
-                        ".\/accounting-and-finance\/expense_report\/assets\/launchpad\/slides\/launchpad-slide2.jpg",
                         ".\/accounting-and-finance\/expense_report\/assets\/launchpad\/slides\/launchpad-slide4.jpg",
-                        ".\/accounting-and-finance\/expense_report\/assets\/launchpad\/slides\/launchpad-slide1.jpg"
+                        ".\/accounting-and-finance\/expense_report\/assets\/launchpad\/slides\/launchpad-slide2.jpg"
                     ]
                 }
             },
@@ -52,18 +52,18 @@
                 "icon": ".\/accounting-and-finance\/invoice_approval\/assets\/icon.png",
                 "card-background": ".\/accounting-and-finance\/invoice_approval\/assets\/card-background.png",
                 "slides": [
-                    ".\/accounting-and-finance\/invoice_approval\/assets\/slides\/slide2.png",
-                    ".\/accounting-and-finance\/invoice_approval\/assets\/slides\/slide3.png",
                     ".\/accounting-and-finance\/invoice_approval\/assets\/slides\/slide4.png",
-                    ".\/accounting-and-finance\/invoice_approval\/assets\/slides\/slide1.png"
+                    ".\/accounting-and-finance\/invoice_approval\/assets\/slides\/slide3.png",
+                    ".\/accounting-and-finance\/invoice_approval\/assets\/slides\/slide1.png",
+                    ".\/accounting-and-finance\/invoice_approval\/assets\/slides\/slide2.png"
                 ],
                 "launchpad": {
                     "process-card-background": "",
                     "slides": [
+                        ".\/accounting-and-finance\/invoice_approval\/assets\/launchpad\/slides\/launchpad-slide1.jpg",
                         ".\/accounting-and-finance\/invoice_approval\/assets\/launchpad\/slides\/launchpad-slide3.jpg",
-                        ".\/accounting-and-finance\/invoice_approval\/assets\/launchpad\/slides\/launchpad-slide2.jpg",
                         ".\/accounting-and-finance\/invoice_approval\/assets\/launchpad\/slides\/launchpad-slide4.jpg",
-                        ".\/accounting-and-finance\/invoice_approval\/assets\/launchpad\/slides\/launchpad-slide1.jpg"
+                        ".\/accounting-and-finance\/invoice_approval\/assets\/launchpad\/slides\/launchpad-slide2.jpg"
                     ]
                 }
             },

--- a/index.json
+++ b/index.json
@@ -1,9 +1,7 @@
 {
     "accounting-and-finance": {
         "expense_report": {
-            "helper_process_hash": "84fe0234ac04ba1747a5e4d94e88429b61c472d4",
             "helper_process": ".\/accounting-and-finance\/expense_report\/process_helper_export.json",
-            "template_process_hash": "9127188deb597df15107ab380e1cd222299e61dc",
             "template_process": ".\/accounting-and-finance\/expense_report\/process_template_export.json",
             "config_collection": "",
             "template_details": {
@@ -12,7 +10,9 @@
                 "modal-excerpt": "Access Real-Time Data and On-Demand Approval for Expenses",
                 "modal-description": "Improve Expense Oversight with Efficient Data Management",
                 "version": "2.1.1 ",
-                "unique-template-id": "expense_report"
+                "unique-template-id": "expense_report",
+                "helper_process_hash": "84fe0234ac04ba1747a5e4d94e88429b61c472d4",
+                "template_process_hash": "9127188deb597df15107ab380e1cd222299e61dc"
             },
             "assets": {
                 "icon": ".\/accounting-and-finance\/expense_report\/assets\/icon.png",
@@ -35,9 +35,7 @@
             "connected_accounts": []
         },
         "invoice_approval": {
-            "helper_process_hash": "a9ddb4f9656e3634df0cd718b1d1f2ab8143b028",
             "helper_process": ".\/accounting-and-finance\/invoice_approval\/process_helper_export.json",
-            "template_process_hash": "d66789e831d0564a2dbee235949a9f1b67716a46",
             "template_process": ".\/accounting-and-finance\/invoice_approval\/process_template_export.json",
             "config_collection": "",
             "template_details": {
@@ -46,7 +44,9 @@
                 "modal-excerpt": "Gather real-time data and approval on demand for invoices",
                 "modal-description": "Drive action and measure your impact with a continuous, real-time tracking of invoices",
                 "version": "2.1.14",
-                "unique-template-id": "invoice_approval"
+                "unique-template-id": "invoice_approval",
+                "helper_process_hash": "a9ddb4f9656e3634df0cd718b1d1f2ab8143b028",
+                "template_process_hash": "d66789e831d0564a2dbee235949a9f1b67716a46"
             },
             "assets": {
                 "icon": ".\/accounting-and-finance\/invoice_approval\/assets\/icon.png",


### PR DESCRIPTION
This PR implements hashing for the helper process and process template to reduce database bloat when running the sync command. The hashing mechanism generates a unique hash for each process, which is then used to check for any changes within the processes. If the hash has changed since the last sync, indicating that the process has been modified, only then are the processes imported into the instance. This approach prevents the processes from being imported every time the sync command is run, thereby eliminating unintended database bloat, particularly in the asset versions table.